### PR TITLE
update lazy_static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ license = "MPL-2.0"
 publish = true
 
 [dependencies]
-lazy_static = "0.2"
+lazy_static = "1.4"


### PR DESCRIPTION
Hi there, I'm using your lib and its great. Today I'm trying to fix this clippy lint [multiple crate versions](https://rust-lang.github.io/rust-clippy/master/index.html#multiple_crate_versions). This is the only crate I use that still uses a pre 1.0 lazy_static.

Have a nice day!